### PR TITLE
Add Trilogy adapter support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,12 @@ if rails_version == "main"
 else
   gem "rails", "~> #{rails_version}"
 end
+
+# Different versions of Rails will depend on different versions
+# of sqlite3. Defaulting to the version depended on by 6.1.0.
+#
+# @see https://github.com/rails/rails/blob/v6.1.0/Gemfile.lock#L615
+sqlite3_version = ENV["SQLITE3_VERSION"] || "1.4.0"
+gem "sqlite3", "~> #{sqlite3_version}"
+
+gem "activerecord-trilogy-adapter", "~> 3.1"

--- a/Rakefile
+++ b/Rakefile
@@ -5,11 +5,18 @@ task :default => ['test:all']
 
 namespace :test do
   desc "test all drivers"
-  task :all => [:mysql2, :postgresql, :sqlite]
+  task :all => [:mysql2, :trilogy, :postgresql, :sqlite]
 
   desc "test mysql2 driver"
   task :mysql2 do
-    sh "DRIVER=mysql2 bundle exec ruby -Ilib -Itest test/*_test.rb"
+    username = ENV.fetch('DB_USERNAME_MYSQL2', 'root')
+    sh "DRIVER=mysql2 DB_USERNAME=#{username} bundle exec ruby -Ilib -Itest test/*_test.rb"
+  end
+
+  desc "test trilogy driver"
+  task :trilogy do
+    username = ENV.fetch("DB_USERNAME_TRILOGY", "root")
+    sh "DRIVER=trilogy DB_USERNAME=#{username} bundle exec ruby -Ilib -Itest test/*_test.rb"
   end
 
   desc "test PostgreSQL driver"
@@ -34,12 +41,12 @@ namespace :db do
 
     desc "create MySQL database"
     task :create do
-      sh 'mysql -u root -e "create database marginalia_test;"'
+      sh "mysql -u #{ENV.fetch('DB_USERNAME', 'root')} -e \"create database marginalia_test;\""
     end
 
     desc "drop MySQL database"
     task :drop do
-      sh 'mysql -u root -e "drop database if exists marginalia_test;"'
+      sh "mysql -u #{ENV.fetch('DB_USERNAME', 'root')} -e \"drop database if exists marginalia_test;\""
     end
   end
 

--- a/lib/marginalia/railtie.rb
+++ b/lib/marginalia/railtie.rb
@@ -69,6 +69,12 @@ module Marginalia
           include Marginalia::ActiveRecordInstrumentation
         end
       end
+
+      if defined? ActiveRecord::ConnectionAdapters::TrilogyAdapter
+        ActiveRecord::ConnectionAdapters::TrilogyAdapter.module_eval do
+          include Marginalia::ActiveRecordInstrumentation
+        end
+      end
     end
   end
 end

--- a/marginalia.gemspec
+++ b/marginalia.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "actionpack", ">= 5.2"
   gem.add_runtime_dependency "activerecord", ">= 5.2"
+  gem.add_development_dependency "activerecord-trilogy-adapter"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "mysql2"
   gem.add_development_dependency "pg"


### PR DESCRIPTION
## What / Why?
[Marginalia has been incorporated into Rails 7.0.](https://rubyonrails.org/2021/12/15/Rails-7-fulfilling-a-vision#trace-query-origins-with-marginalia-style-tagging)

[Trilogy has been incorporated into Rails 7.1 and might be the default MySQL adapter in 8.0](https://rubyonrails.org/2023/10/5/Rails-7-1-0-has-been-released#built-in-support-for-the-trilogy-mysql-adapter)

We are on Rails 6.x and have proactively migrated to Trilogy via [activerecord-trilogy-adapter](https://github.com/trilogy-libraries/activerecord-trilogy-adapter). In doing so, we have lost the query comments.

This PR:
* Adds support the Trilogy adapter.
* Allows overriding the MySQL database username (default: `root`) as the root user on our dev machines require password auth while the `vagrant` user does not.
* Updates the `test_database` test so it will pass with `sqlite3`.

Note: I don't think there's a lot of value in issuing this PR to the upstream repo, but I can do that if we see value.

## How was it tested?

Ran full test locally:
<details><summary>Ran full test locally</summary>

**Note:** `vagrant` is the MySQL user on my dev vm that can login without a password.

```
vagrant@i20240322:~/Projects/marginalia (trilogy=) $ DB_USERNAME_MYSQL2=vagrant DB_USERNAME_TRILOGY=vagrant bundle exec rake
DRIVER=mysql2 DB_USERNAME=vagrant bundle exec ruby -Ilib -Itest test/*_test.rb
Run options: --seed 50956

# Running:

.[ActiveJob] [PostsJob] [38917d70-c168-4c14-8c38-28090d7e5a6e] Performing PostsJob (Job ID: 38917d70-c168-4c14-8c38-28090d7e5a6e) from Inline(default) enqueued at 2024-07-31T21:20:32Z
[ActiveJob] [PostsJob] [38917d70-c168-4c14-8c38-28090d7e5a6e] Performed PostsJob (Job ID: 38917d70-c168-4c14-8c38-28090d7e5a6e) from Inline(default) in 12.91ms
[ActiveJob] Enqueued PostsJob (Job ID: 38917d70-c168-4c14-8c38-28090d7e5a6e) to Inline(default)
.................2024-07-31T21:20:33.121Z pid=342933 tid=79rd INFO: Sidekiq 7.3.0 connecting to Redis with options {:size=>10, :pool_name=>"internal", :url=>nil}
....[ActiveJob] [PostsJob] [83bdf1d6-6989-4aa8-8d19-a3910081ffd6] Performing PostsJob (Job ID: 83bdf1d6-6989-4aa8-8d19-a3910081ffd6) from Inline(default) enqueued at 2024-07-31T21:20:33Z
[ActiveJob] [PostsJob] [83bdf1d6-6989-4aa8-8d19-a3910081ffd6] Performed PostsJob (Job ID: 83bdf1d6-6989-4aa8-8d19-a3910081ffd6) from Inline(default) in 0.32ms
[ActiveJob] Enqueued PostsJob (Job ID: 83bdf1d6-6989-4aa8-8d19-a3910081ffd6) to Inline(default)
....

Finished in 0.184301s, 141.0733 runs/s, 325.5537 assertions/s.
26 runs, 60 assertions, 0 failures, 0 errors, 0 skips
DRIVER=trilogy DB_USERNAME=vagrant bundle exec ruby -Ilib -Itest test/*_test.rb
Run options: --seed 61227

# Running:

........2024-07-31T21:20:34.425Z pid=342950 tid=79qm INFO: Sidekiq 7.3.0 connecting to Redis with options {:size=>10, :pool_name=>"internal", :url=>nil}
..[ActiveJob] [PostsJob] [e82be85d-3a7e-4e3b-ad05-1fe93568b222] Performing PostsJob (Job ID: e82be85d-3a7e-4e3b-ad05-1fe93568b222) from Inline(default) enqueued at 2024-07-31T21:20:34Z
[ActiveJob] [PostsJob] [e82be85d-3a7e-4e3b-ad05-1fe93568b222] Performed PostsJob (Job ID: e82be85d-3a7e-4e3b-ad05-1fe93568b222) from Inline(default) in 6.36ms
[ActiveJob] Enqueued PostsJob (Job ID: e82be85d-3a7e-4e3b-ad05-1fe93568b222) to Inline(default)
................[ActiveJob] [PostsJob] [c57c58c6-0f22-4195-b142-cc2b1621bc6b] Performing PostsJob (Job ID: c57c58c6-0f22-4195-b142-cc2b1621bc6b) from Inline(default) enqueued at 2024-07-31T21:20:34Z
[ActiveJob] [PostsJob] [c57c58c6-0f22-4195-b142-cc2b1621bc6b] Performed PostsJob (Job ID: c57c58c6-0f22-4195-b142-cc2b1621bc6b) from Inline(default) in 0.36ms
[ActiveJob] Enqueued PostsJob (Job ID: c57c58c6-0f22-4195-b142-cc2b1621bc6b) to Inline(default)
..

Finished in 0.187439s, 149.3820 runs/s, 320.1043 assertions/s.
28 runs, 60 assertions, 0 failures, 0 errors, 0 skips
DRIVER=postgresql DB_USERNAME=postgres bundle exec ruby -Ilib -Itest test/*_test.rb
PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from /opt/ruby3.1/lib64/ruby/gems/3.1.0/gems/activerecord-6.1.7.8/lib/active_record/connection_adapters/postgresql_adapter.rb:883:in `new'
Run options: --seed 12363

# Running:

.....[ActiveJob] [PostsJob] [abd374eb-2fb4-4479-9cd6-46a94d3544d6] Performing PostsJob (Job ID: abd374eb-2fb4-4479-9cd6-46a94d3544d6) from Inline(default) enqueued at 2024-07-31T21:20:35Z
[ActiveJob] [PostsJob] [abd374eb-2fb4-4479-9cd6-46a94d3544d6] Performed PostsJob (Job ID: abd374eb-2fb4-4479-9cd6-46a94d3544d6) from Inline(default) in 6.38ms
[ActiveJob] Enqueued PostsJob (Job ID: abd374eb-2fb4-4479-9cd6-46a94d3544d6) to Inline(default)
...2024-07-31T21:20:35.850Z pid=342968 tid=79qo INFO: Sidekiq 7.3.0 connecting to Redis with options {:size=>10, :pool_name=>"internal", :url=>nil}
.........[ActiveJob] [PostsJob] [f6d8ebf6-01ee-4250-a347-10937d770a76] Performing PostsJob (Job ID: f6d8ebf6-01ee-4250-a347-10937d770a76) from Inline(default) enqueued at 2024-07-31T21:20:35Z
[ActiveJob] [PostsJob] [f6d8ebf6-01ee-4250-a347-10937d770a76] Performed PostsJob (Job ID: f6d8ebf6-01ee-4250-a347-10937d770a76) from Inline(default) in 0.36ms
[ActiveJob] Enqueued PostsJob (Job ID: f6d8ebf6-01ee-4250-a347-10937d770a76) to Inline(default)
..........

Finished in 0.192084s, 140.5635 runs/s, 307.1572 assertions/s.
27 runs, 59 assertions, 0 failures, 0 errors, 0 skips
DRIVER=sqlite3 bundle exec ruby -Ilib -Itest test/*_test.rb
-- create_table("posts", {:force=>true})
   -> 0.0005s
Run options: --seed 1250

# Running:

....[ActiveJob] [PostsJob] [becfe2a2-014a-423e-9ba1-712c7e21fae4] Performing PostsJob (Job ID: becfe2a2-014a-423e-9ba1-712c7e21fae4) from Inline(default) enqueued at 2024-07-31T21:20:37Z
[ActiveJob] [PostsJob] [becfe2a2-014a-423e-9ba1-712c7e21fae4] Performed PostsJob (Job ID: becfe2a2-014a-423e-9ba1-712c7e21fae4) from Inline(default) in 5.81ms
[ActiveJob] Enqueued PostsJob (Job ID: becfe2a2-014a-423e-9ba1-712c7e21fae4) to Inline(default)
....2024-07-31T21:20:37.227Z pid=342986 tid=79sy INFO: Sidekiq 7.3.0 connecting to Redis with options {:size=>10, :pool_name=>"internal", :url=>nil}
..........[ActiveJob] [PostsJob] [b2c9f913-f35e-4d97-96a4-1f75ab138079] Performing PostsJob (Job ID: b2c9f913-f35e-4d97-96a4-1f75ab138079) from Inline(default) enqueued at 2024-07-31T21:20:37Z
[ActiveJob] [PostsJob] [b2c9f913-f35e-4d97-96a4-1f75ab138079] Performed PostsJob (Job ID: b2c9f913-f35e-4d97-96a4-1f75ab138079) from Inline(default) in 0.26ms
[ActiveJob] Enqueued PostsJob (Job ID: b2c9f913-f35e-4d97-96a4-1f75ab138079) to Inline(default)
.......

Finished in 0.168250s, 148.5883 runs/s, 350.6685 assertions/s.
25 runs, 59 assertions, 0 failures, 0 errors, 0 skips
```
</details>

<details><summary>Ran against our monolith</summary>

Updated the monolith to target this SHA:
```
gem 'marginalia', '~> 1.6', github: 'EasyPost/marginalia', ref: 'b5946843a135536e61fa149771544babe22f6c43'
```

Ran a sample test and confirmed statements have query comments:
```
[1722461823] DEBUG :   Form Load (0.2ms)  SELECT `forms`.* FROM `forms` WHERE `forms`.`shipment_id` = 1 /*application:REDACTED,connection_id:REDACTED,hostname:REDACTED,pid:REDACTED,line:REDACTED*/

[1722461824] DEBUG :    (0.2ms)  DELETE FROM `forms` WHERE 1=1 /*application:REDACTED,connection_id:REDACTED,hostname:REDACTED,pid:REDACTED,line:REDACTED*/

[1722461824] DEBUG :    (0.1ms)  SET FOREIGN_KEY_CHECKS = 1 /*application:REDACTED,connection_id:REDACTED,hostname:REDACTED,pid:REDACTED,line:REDACTED*/
```
</details>