### PR TITLE
Add comments to insert statments

### DIFF
--- a/lib/marginalia.rb
+++ b/lib/marginalia.rb
@@ -36,6 +36,12 @@ module Marginalia
               alias_method :exec_delete, :exec_delete_with_marginalia
             end
 
+             # Instrument exec_delete since it doesn't call execute internally.
+             if instrumented_class.method_defined?(:exec_insert)
+              alias_method :exec_insert_without_marginalia, :exec_insert
+              alias_method :exec_insert, :exec_insert_with_marginalia
+            end
+
             # Instrument exec_update since it doesn't call execute internally.
             #
             # exec_update is aliased to exec_delete, so we'll alias this explicitly here to ensure
@@ -102,6 +108,11 @@ module Marginalia
       exec_delete_without_marginalia(annotate_sql(sql), *args)
     end
     ruby2_keywords :exec_delete_with_marginalia if respond_to?(:ruby2_keywords, true)
+
+    def exec_insert_with_marginalia(sql, *args)
+      exec_insert_without_marginalia(annotate_sql(sql), *args)
+    end
+    ruby2_keywords :exec_insert_with_marginalia if respond_to?(:ruby2_keywords, true)
 
     def exec_update_with_marginalia(sql, *args)
       exec_update_without_marginalia(annotate_sql(sql), *args)

--- a/test/query_comments_test.rb
+++ b/test/query_comments_test.rb
@@ -151,6 +151,13 @@ class MarginaliaTest < Minitest::Test
       ActiveRecord::Base.connection.unstub(:annotate_sql)
     end
 
+    def test_query_commenting_on_trilogy_insert
+      ActiveRecord::Base.connection.expects(:annotate_sql).returns('insert into posts (id) values (55)').once
+      ActiveRecord::Base.connection.send(:exec_insert, 'insert into posts (id) values (55)')
+    ensure
+      ActiveRecord::Base.connection.unstub(:annotate_sql)
+    end
+
     def test_query_commenting_on_trilogy_delete
       ActiveRecord::Base.connection.expects(:annotate_sql).returns('delete from posts where id = 1').once
       ActiveRecord::Base.connection.send(:exec_delete, 'delete from posts where id = 1')


### PR DESCRIPTION
Dearest Reviewer,

Sometimes there is a need to know where a call to INSERT is coming from. I see that exec_insert has been omited from the list.

I am also unsure why exec_query is behind mysql2 check given it is in the abstract statements
https://github.com/rails/rails/blob/0396f468fc0051bd754dbafc10104b6aa3106b17/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L136-L150

So this takes what was done before and adds in the insert methods

Changes
added insert method change update matching what was done for deletes.

test:
to create the db i needed DB_USERNAME 
`DB_USERNAME_MYSQL2=vagrant DB_USERNAME_TRILOGY=vagrant DB_USERNAME=vagrant bundle exec rake db:mysql:create`

becker